### PR TITLE
Enable scalafmt status check for main

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,8 +18,7 @@ github:
     rebase:  true
 
   protected_branches:
-    main: {}
-    test:
+    main:
       required_status_checks:
         # strict means "Require branches to be up to date before merging".
         strict: false


### PR DESCRIPTION
So I can confirm that the status check is now properly defined which means it should no longer make the `main` branch stuck.

You can verify this by looking at this PR https://github.com/apache/incubator-pekko-sbt-paradox/pull/6. Currently `main` only has the scalafmt status check enabled for the `test` branch and that PR does a PR against that `test` branch.

I also verified that the check fails if the code isn't formatted by deliberately committing unformatted code and it works as expected

![image](https://user-images.githubusercontent.com/2337269/217490403-e0224d4a-05f0-4201-82c9-9fc31fa27f43.png)
