### PR TITLE
Updates sbt-apache-sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ lazy val pekkoTheme = project
   .in(file("theme"))
   .enablePlugins(ParadoxThemePlugin)
   .settings(
-    organization := "org.apache.pekko",
     name := "pekko-theme-paradox",
     libraryDependencies ++= Seq(
       "io.github.jonas" % "paradox-material-theme" % "0.6.0",
@@ -35,7 +34,6 @@ lazy val pekkoPlugin = project
   .enablePlugins(SbtPlugin)
   .settings(
     sbtPlugin := true,
-    organization := "org.apache.pekko",
     name := "pekko-sbt-paradox",
     scriptedLaunchOpts := {
       scriptedLaunchOpts.value ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.3")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.4")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.5")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")


### PR DESCRIPTION
Updates to latest version of sbt-apache-sonatype. Note that `organization` is no longer needed, sbt-apache-sonatype sets this up for you.