### PR TITLE
fix definition lists

### DIFF
--- a/theme/src/main/assets/assets/javascripts/groups.js
+++ b/theme/src/main/assets/assets/javascripts/groups.js
@@ -45,7 +45,7 @@ $(function() {
     return cookieAttr ? cookieAttr.split("=")[1] : "";
   }
 
-  $("dl").has("dt").each(function() {
+  $("dl").has("dt.mdc-tab").each(function() {
     var dl = $(this);
     dl.addClass("tabbed");
     var dts = dl.find("dt");


### PR DESCRIPTION
Before these were accidentally converted into tabs as well as the content was lost.

E.g. https://nightlies.apache.org/pekko/docs/pekko-http/main-snapshot/docs/introduction.html#the-modules-that-make-up-apache-pekko-http

![image](https://user-images.githubusercontent.com/9868/222389299-e73ce50f-d07f-4cec-b50b-e2eff2bfb973.png)
