### PR TITLE
take Lightbend out of default copyright

### DIFF
--- a/plugin/src/main/scala/org/apache/pekko/PekkoParadoxPlugin.scala
+++ b/plugin/src/main/scala/org/apache/pekko/PekkoParadoxPlugin.scala
@@ -29,11 +29,10 @@ object PekkoParadoxPlugin extends AutoPlugin {
   def pekkoParadoxGlobalSettings: Seq[Setting[_]] = Seq(
     paradoxTheme := Some("org.apache.pekko" % "pekko-theme-paradox" % version),
     paradoxNavigationIncludeHeaders := true,
-    pekkoParadoxCopyright in Global :=
-      """Copyright © 2011-2022 <a href="https://www.lightbend.com/">Lightbend, Inc.</a>, © 2022, 2023
-        | <a href="https://apache.org">The Apache Software Foundation</a>.
-        | Apache Pekko, Pekko, and its feather logo are trademarks of The Apache Software Foundation.""".stripMargin,
-    pekkoParadoxGithub in Global := None,
+    Global / pekkoParadoxCopyright :=
+      """Copyright © 2022, 2023 <a href="https://apache.org">The Apache Software Foundation</a>.
+        |Apache Pekko, Pekko, and its feather logo are trademarks of The Apache Software Foundation.""".stripMargin,
+    Global / pekkoParadoxGithub := None,
     Compile / paradoxMaterialTheme := {
       val theme =
         (Compile / paradoxMaterialTheme).value


### PR DESCRIPTION
Things have moved on in https://issues.apache.org/jira/browse/LEGAL-634.

We now need to leave a pure Lightbend copyright in most pages of our web site docs.

Only pages that we have written from scratch, get an ASF copyright. I've made this the default. We do need to write a home page and a download page, etc. And they will get this ASF copyright.

In incubator-pekko, I will set an override to the pekkoParadoxCopyright to set a Lightbend only copyright on all the pages generated by Paradox for that project.