### PR TITLE
remove ASF copyright

### DIFF
--- a/plugin/src/main/scala/org/apache/pekko/PekkoParadoxPlugin.scala
+++ b/plugin/src/main/scala/org/apache/pekko/PekkoParadoxPlugin.scala
@@ -30,8 +30,7 @@ object PekkoParadoxPlugin extends AutoPlugin {
     paradoxTheme := Some("org.apache.pekko" % "pekko-theme-paradox" % version),
     paradoxNavigationIncludeHeaders := true,
     pekkoParadoxCopyright in Global :=
-      """Copyright © 2011-2022 <a href="https://www.lightbend.com/">Lightbend, Inc.</a>, © 2022, 2023
-        | <a href="https://apache.org">The Apache Software Foundation</a>.
+      """Copyright © 2011-2022 <a href="https://www.lightbend.com/">Lightbend, Inc.</a>.
         | Apache Pekko, Pekko, and its feather logo are trademarks of The Apache Software Foundation.""".stripMargin,
     pekkoParadoxGithub in Global := None,
     Compile / paradoxMaterialTheme := {


### PR DESCRIPTION
relates to https://issues.apache.org/jira/browse/LEGAL-634 - we need to acknowledge Lightbend copyright because they wrote most of the site contents but we don't need to assert an ASF copyright