### PR TITLE
update license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -204,9 +204,31 @@
 
 pekko-sbt-paradox contains scripting adapted from paradox-material-theme version 0.6.0,
 which was released under an MIT license <https://github.com/jonas/paradox-material-theme>.
+- plugin/src/main/scala/org/apache/pekko/SearchIndex.scala
+- theme/src/main/assets/page.st
+- theme/src/main/assets/partials/footer.st
+- theme/src/main/assets/partials/nav.st
 
 Copyright (c) 2016-2018 Martin Donath <martin.donath@squidfunk.com>
 Copyright (c) 2017-2018 Jonas Fonseca <jonas.fonseca@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
 
 ---------------
 

--- a/plugin/src/main/scala/org/apache/pekko/SearchIndex.scala
+++ b/plugin/src/main/scala/org/apache/pekko/SearchIndex.scala
@@ -1,9 +1,4 @@
-/**
- * Copied and adopted from https://github.com/jonas/paradox-material-theme/blob/2d57fe0567ea9fe7e8de14faef4fa777841d505a/plugin/src/main/scala/io.github.jonas.paradox.material.theme/SearchIndex.scala
- *
- * Copyright (c) 2017-2018 Jonas Fonseca
- * License: MIT
- */
+// Copied and adapted from https://github.com/jonas/paradox-material-theme/blob/2d57fe0567ea9fe7e8de14faef4fa777841d505a/plugin/src/main/scala/io.github.jonas.paradox.material.theme/SearchIndex.scala
 
 package org.apache.pekko
 

--- a/theme/src/main/assets/assets/javascripts/paradox-material-theme.js
+++ b/theme/src/main/assets/assets/javascripts/paradox-material-theme.js
@@ -1,10 +1,11 @@
 /*!
- Adapted from paradox-material-theme 0.6.0 to simplify switching to a tab.
-
  Paradox Material Theme
  Copyright (c) 2017 Jonas Fonseca
  License: MIT
 */
+
+// Adapted from paradox-material-theme 0.6.0 to simplify switching to a tab.
+// https://github.com/jonas/paradox-material-theme/blob/2d57fe0567ea9fe7e8de14faef4fa777841d505a/theme/src/main/assets/assets/javascripts/paradox-material-theme.js
 
 function initParadoxMaterialTheme() {
   // callout -> ammonition

--- a/theme/src/main/assets/page.st
+++ b/theme/src/main/assets/page.st
@@ -1,6 +1,4 @@
 $!
-  Adapted from paradox-material-theme version 0.6.0 to include more scripts.
-
   Copyright (c) 2016-2018 Martin Donath <martin.donath@squidfunk.com>
   Copyright (c) 2017-2018 Jonas Fonseca <jonas.fonseca@gmail.com>
 
@@ -22,6 +20,8 @@ $!
   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
   IN THE SOFTWARE.
 !$
+<!-- Adapted from paradox-material-theme version 0.6.0 -->
+<!-- https://github.com/jonas/paradox-material-theme/blob/2d57fe0567ea9fe7e8de14faef4fa777841d505a/theme/src/main/assets/page.st -->
 <!DOCTYPE html>
 <html lang="$page.properties.("material.language"); null="en"$" class="no-js">
   <head>

--- a/theme/src/main/assets/partials/footer.st
+++ b/theme/src/main/assets/partials/footer.st
@@ -1,6 +1,4 @@
 $!
-  Adapted from paradox-material-theme version 0.6.0
-
   Copyright (c) 2016-2018 Martin Donath <martin.donath@squidfunk.com>
   Copyright (c) 2017-2018 Jonas Fonseca <jonas.fonseca@gmail.com>
 
@@ -22,6 +20,8 @@ $!
   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
   IN THE SOFTWARE.
 !$
+<!-- Adapted from paradox-material-theme version 0.6.0 -->
+<!-- https://github.com/jonas/paradox-material-theme/blob/2d57fe0567ea9fe7e8de14faef4fa777841d505a/theme/src/main/assets/partials/footer.st -->
 <footer class="md-footer">
   $ if (page.next.html || page.prev.html) $
     <div class="md-footer-nav">

--- a/theme/src/main/assets/partials/nav.st
+++ b/theme/src/main/assets/partials/nav.st
@@ -1,6 +1,4 @@
 $!
-  Adapted from paradox-material-theme version 0.6.0
-
   Copyright (c) 2016-2018 Martin Donath <martin.donath@squidfunk.com>
   Copyright (c) 2017-2018 Jonas Fonseca <jonas.fonseca@gmail.com>
 
@@ -22,6 +20,8 @@ $!
   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
   IN THE SOFTWARE.
 !$
+<!-- Adapted from paradox-material-theme version 0.6.0 -->
+<!-- https://github.com/jonas/paradox-material-theme/blob/2d57fe0567ea9fe7e8de14faef4fa777841d505a/theme/src/main/assets/partials/nav.st -->
 <nav class="md-nav md-nav--primary" data-md-level="0" style="visibility: hidden">
   <label class="md-nav__title md-nav__title--site" for="drawer">
     <a href="$page.home.href$" title="$page.home.title$" class="md-nav__button md-logo">


### PR DESCRIPTION
* key aim is to keep the original headers without any mods
* add some extra comment lines afterwards, adding more context
* add full MIT license for paradox-material-theme to our LICENSE
* see comments inline