### PR TITLE
ignore local build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ project/boot/
 project/plugins/project/
 .history
 .cache
+.bsp/
+.idea/
 .lib/
 
 ### Scala template


### PR DESCRIPTION
* sbt-source-dist plugin uses .gitignore to decide which local files to leave out of the source dist
* these dirs are ending up in the source dist for this repo and they contain local path stuff that shouldn't really be in the source dist