### PR TITLE
Better clarify documentation references

### DIFF
--- a/theme/src/main/assets/assets/javascripts/groups.js
+++ b/theme/src/main/assets/assets/javascripts/groups.js
@@ -25,7 +25,7 @@ $(function() {
   if(cookieTg != "")
     currentGroups = JSON.parse(cookieTg);
 
-  // https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie for more information
   function setCookie(cookieName, cookieValue, daysToExpire) {
     if (!daysToExpire) daysToExpire = 365;
     const now = new Date();
@@ -37,7 +37,8 @@ $(function() {
     document.cookie = `${cookieName}=${encodeURIComponent(cookieValue)};expires=${now.toUTCString()};path=/;samesite=lax`;
   }
 
-  // https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#Example_2_Get_a_sample_cookie_named_test2
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#Example_2_Get_a_sample_cookie_named_test2 for
+  // more information
   function getCookie(cookieName) {
     const cookieAttr = decodeURIComponent(document.cookie)
         .split(";")


### PR DESCRIPTION
The context of this discussion is https://lists.apache.org/thread/bh1vqjnf7vjzyzhgbcv979g0hl6dly0s . The intent of the PR is just make the wording of the referenced docs ultra clear i.e. the code on this page is **NOT** derived or copied from MDN, rather the links are there as references in case you want more information on how cookies work.