### PR TITLE
change thanks link

### DIFF
--- a/theme/src/main/assets/partials/extra_nav_links.st
+++ b/theme/src/main/assets/partials/extra_nav_links.st
@@ -24,5 +24,5 @@ $!
       <li class="md-nav__item"><a href="https://privacy.apache.org/policies/privacy-policy-public.html"><i class="md-icon">link</i>&nbsp;Privacy</a></li>
       <li class="md-nav__item"><a href="https://www.apache.org/events/current-event.html"><i class="md-icon">link</i>&nbsp;Events</a></li>
       <li class="md-nav__item"><a href="https://www.apache.org/foundation/sponsorship.html"><i class="md-icon">link</i>&nbsp;Donate</a></li>
-      <li class="md-nav__item"><a href="https://www.apache.org/foundation/thanks.html"><i class="md-icon">link</i>&nbsp;Thanks</a></li>
+      <li class="md-nav__item"><a href="https://www.apache.org/foundation/sponsors"><i class="md-icon">link</i>&nbsp;Thanks</a></li>
 </ul>


### PR DESCRIPTION
The old link is now redirecting to https://www.apache.org/foundation/sponsors

It seems tidier to link to the new link.