### PR TITLE
feat: Support configurable display of version

### DIFF
--- a/theme/src/main/assets/page.st
+++ b/theme/src/main/assets/page.st
@@ -118,6 +118,13 @@ $!
                   </a>
                 </div>
               $ endif $
+              $ if (page.properties.("versioning.display")) $
+                <div class="print-only">
+                  <span class="md-source-file md-version">
+                    $page.properties.("project.version.short")$
+                  </span>
+                </div>
+              $ endif $
             </article>
           </div>
         </div>

--- a/theme/src/main/assets/page.st
+++ b/theme/src/main/assets/page.st
@@ -118,11 +118,6 @@ $!
                   </a>
                 </div>
               $ endif $
-              <div class="print-only">
-                <span class="md-source-file md-version">
-                  $page.properties.("project.version.short")$
-                </span>
-              </div>
             </article>
           </div>
         </div>

--- a/theme/src/main/assets/page.st
+++ b/theme/src/main/assets/page.st
@@ -118,7 +118,7 @@ $!
                   </a>
                 </div>
               $ endif $
-              $ if (page.properties.("versioning.display")) $
+              $ if (!page.properties.("disabled.versioning.display")) $
                 <div class="print-only">
                   <span class="md-source-file md-version">
                     $page.properties.("project.version.short")$

--- a/theme/src/main/assets/page.st
+++ b/theme/src/main/assets/page.st
@@ -118,7 +118,7 @@ $!
                   </a>
                 </div>
               $ endif $
-              $ if (!page.properties.("disabled.versioning.display")) $
+              $ if (!page.property_is.("disabled.versioning.display").("true")) $
                 <div class="print-only">
                   <span class="md-source-file md-version">
                     $page.properties.("project.version.short")$

--- a/theme/src/main/assets/partials/nav.st
+++ b/theme/src/main/assets/partials/nav.st
@@ -52,3 +52,13 @@ $!
 
   $extra_nav_links()$
 </nav>
+$ if (page.properties.("versioning.display")) $
+  <ul style="display: none">
+    <li class="md-nav__item md-version" id="project.version">
+      <label class="md-nav__link" for="__version">
+        <i class="md-icon" title="Version">label_outline</i> $page.properties.("project.version.short")$
+      </label>
+    </li>
+  </ul>
+$ endif $
+

--- a/theme/src/main/assets/partials/nav.st
+++ b/theme/src/main/assets/partials/nav.st
@@ -52,7 +52,7 @@ $!
 
   $extra_nav_links()$
 </nav>
-$ if (!page.properties.("disabled.versioning.display")) $
+$ if (!page.property_is.("disabled.versioning.display").("true")) $
   <ul style="display: none">
     <li class="md-nav__item md-version" id="project.version">
       <label class="md-nav__link" for="__version">

--- a/theme/src/main/assets/partials/nav.st
+++ b/theme/src/main/assets/partials/nav.st
@@ -52,10 +52,3 @@ $!
 
   $extra_nav_links()$
 </nav>
-<ul style="display: none">
-  <li class="md-nav__item md-version" id="project.version">
-    <label class="md-nav__link" for="__version">
-      <i class="md-icon" title="Version">label_outline</i> $page.properties.("project.version.short")$
-    </label>
-  </li>
-</ul>

--- a/theme/src/main/assets/partials/nav.st
+++ b/theme/src/main/assets/partials/nav.st
@@ -52,7 +52,7 @@ $!
 
   $extra_nav_links()$
 </nav>
-$ if (page.properties.("versioning.display")) $
+$ if (!page.properties.("disabled.versioning.display")) $
   <ul style="display: none">
     <li class="md-nav__item md-version" id="project.version">
       <label class="md-nav__link" for="__version">


### PR DESCRIPTION
Refs: https://github.com/apache/incubator-pekko-site/issues/33

Then we can hidden page versioning on "top-level-page" of Pekko website, and still display by default for other project, all those stuff can switch via configuration.

## usage

set it by specifying the flag in `build.sbt`

```
paradoxProperties += ("disabled.versioning.display" -> "true")
```

## example

![截屏2023-10-13 19 48 56](https://github.com/apache/incubator-pekko-sbt-paradox/assets/26020358/76bdfc2f-ea5c-4c1f-92f9-6cd0023af501)

