### PR TITLE
Adding styling for tables in paradox

### DIFF
--- a/theme/src/main/assets/assets/stylesheets/pekko-theme.css
+++ b/theme/src/main/assets/assets/stylesheets/pekko-theme.css
@@ -80,3 +80,16 @@ pre:hover .snippet-button.go-to-source::before {
 a.snippet-button.go-to-source:hover::before, .snippet-button.go-to-source:active::before {
   color: #ff9100;
 }
+
+/* style for tables */
+tbody th {
+  font-weight: bold;
+}
+
+tbody th, tbody td {
+  padding: 5px;
+}
+
+tbody tr:nth-child(even) {
+  background-color: #eaeaea;
+}


### PR DESCRIPTION
This PR add styling for tables in paradox. The goal is to display the tables in the docs more clearly.

## Before

![Screenshot 2023-11-12 181416](https://github.com/apache/incubator-pekko-sbt-paradox/assets/8921095/d7d8644b-2a9e-4672-81ad-d8c5c844bd70)


## After

![Screenshot 2023-11-12 181356](https://github.com/apache/incubator-pekko-sbt-paradox/assets/8921095/beb03822-f7da-4224-b58f-2cd002407508)
