### PR TITLE
Upgrade dependencies to move away from repo.scala-sbt.org

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,9 +75,9 @@ lazy val pekkoPlugin = project
     addSbtPlugin(
       // When updating the sbt-paradox version,
       // remember to also update project/plugins.sbt
-      "com.lightbend.paradox" % "sbt-paradox" % "0.10.3"),
-    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.0.0"),
-    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.0"),
+      "com.lightbend.paradox" % "sbt-paradox" % "0.10.6"),
+    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0"),
+    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1"),
     addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % "0.6.0"),
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "pekko-paradox.properties"

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ lazy val pekkoPlugin = project
       "com.lightbend.paradox" % "sbt-paradox" % "0.10.6"),
     addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0"),
     addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1"),
-    addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % "0.6.0"),
+    addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % "0.7.0"),
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "pekko-paradox.properties"
       IO.write(file, s"pekko.paradox.version=${version.value}")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@
 
 // When updating the sbt-paradox version,
 // remember to also update build.sbt
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.3")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.6")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@
 // When updating the sbt-paradox version,
 // remember to also update build.sbt
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-theme" % "0.10.6")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.10")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.10")


### PR DESCRIPTION
I started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts`. 

* sbt-paradox 0.10.3 (up to 0.10.5) still hosted on repo.scala-sbt.org, migrated to maven central with latest 0.10.6
* sbt-dynver 4.1.1 still hosted on repo.scala-sbt.org, latest version on maven central however.

This pull request depends:
- https://github.com/lightbend/sbt-paradox-apidoc/pull/271
  EDIT: https://github.com/lightbend/sbt-paradox-apidoc/releases/tag/v1.1.0
- https://github.com/lightbend/sbt-paradox-project-info/pull/40
  EDIT: https://github.com/lightbend/sbt-paradox-project-info/releases/tag/v3.0.1

TODO:
- [ ] Upgrade `sbt-paradox-material-theme` (needs to move under `com.github.sbt` and a new release).
- [ ] cut new pekko-sbt-paradox release
- [ ] Upgrade in https://github.com/apache/incubator-pekko-http/pull/453 and https://github.com/apache/incubator-pekko/pull/1061, so in build.sbt we don't need the three force() dependencies anymore, but instead nail down parboiled to v1.4.0.
- [ ] Also in incubator-pekko-connectors can be done the same, also (https://github.com/apache/incubator-pekko-connectors/pull/362) needs to be upgraded

After merging this can you cut a 1.0.1 release? Thanks!