### PR TITLE
Make incubator notice optional

### DIFF
--- a/plugin/src/main/scala/org/apache/pekko/PekkoParadoxPlugin.scala
+++ b/plugin/src/main/scala/org/apache/pekko/PekkoParadoxPlugin.scala
@@ -31,10 +31,14 @@ object PekkoParadoxPlugin extends AutoPlugin {
   object autoImport {
     val pekkoParadoxCopyright = settingKey[String]("Copyright text to use in docs footer")
     val pekkoParadoxGithub = settingKey[Option[String]]("Link to Github repository")
+    val pekkoParadoxIncubatorNotice = settingKey[Option[String]]("Whether to include the ASF incubator notice")
   }
   import autoImport._
 
   val version = ParadoxPlugin.readProperty("pekko-paradox.properties", "pekko.paradox.version")
+
+  val incubatorNoticeText =
+    "Apache Pekko is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF."
 
   override def requires = ParadoxPlugin
 
@@ -46,12 +50,17 @@ object PekkoParadoxPlugin extends AutoPlugin {
   def pekkoParadoxGlobalSettings: Seq[Setting[_]] = Seq(
     paradoxTheme := Some("org.apache.pekko" % "pekko-theme-paradox" % version),
     // Target hostname for static assets (CSS, JS, Icons, Font)
-    paradoxProperties ++= Map("assets.hostname" -> "https://pekko.apache.org/"),
+    paradoxProperties ++= {
+      Map("assets.hostname" -> "https://pekko.apache.org/") ++
+      pekkoParadoxIncubatorNotice.value.map(incubatorNotice => Map("incubator.notice" -> incubatorNotice)).getOrElse(
+        Map.empty)
+    },
     paradoxNavigationIncludeHeaders := true,
     pekkoParadoxCopyright in Global :=
       """Copyright © 2011-2022 <a href="https://www.lightbend.com/">Lightbend, Inc</a>.
         | Apache Pekko, Pekko, and its feather logo are trademarks of The Apache Software Foundation.""".stripMargin,
     pekkoParadoxGithub in Global := None,
+    pekkoParadoxIncubatorNotice in Global := Some(incubatorNoticeText),
     Compile / paradoxMaterialTheme := {
       val theme =
         (Compile / paradoxMaterialTheme).value

--- a/theme/src/main/assets/partials/footer.st
+++ b/theme/src/main/assets/partials/footer.st
@@ -61,16 +61,18 @@ $!
   $endif$
   <div class="md-footer-meta md-typeset">
     <div class="md-footer-meta__inner md-grid">
-      <div class="logo">
-        <a href="https://incubator.apache.org/" one-link-mark="yes">
-          <img src="$page.properties.("assets.hostname")$assets/images/apache-incubator.svg" alt="Apache Incubator logo" id="incubator__logo">
-        </a>
-      </div>
-      <div class="incubation-disclaimer">
-        <p>
-          Apache Pekko is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-        </p>
-      </div>
+      $ if (page.properties.("incubator.notice")) $
+        <div class="logo">
+          <a href="https://incubator.apache.org/" one-link-mark="yes">
+            <img src="$page.properties.("assets.hostname")$assets/images/apache-incubator.svg" alt="Apache Incubator logo" id="incubator__logo">
+          </a>
+        </div>
+        <div class="incubation-disclaimer">
+          <p>
+            $page.properties.("incubator.notice")$
+          </p>
+        </div>
+      $ endif $
       <div class="md-footer-copyright">
         $ if (page.properties.("material.copyright")) $
           <div class="md-footer-copyright__highlight">


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-sbt-paradox/issues/115

Trying this with pekko core, this is what it looks like with this change (there should be no difference in rendered text)

![image](https://github.com/apache/incubator-pekko-sbt-paradox/assets/2337269/496f4ba3-f9d2-4a37-a26f-cdfc32f8f207)

And when setting `pekkoParadoxIncubatorNotice` to `None`

![image](https://github.com/apache/incubator-pekko-sbt-paradox/assets/2337269/fa3507c8-8fb3-4cd1-9cb4-1a973d898ba5)