### PR TITLE
Exclude dependencies for sbt-paradox-apidoc/sbt-paradox-project-info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,10 +76,15 @@ lazy val pekkoPlugin = project
     addSbtPlugin(
       // When updating the sbt-paradox version,
       // remember to also update project/plugins.sbt
-      ("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").exclude("com.typesafe.sbt", "sbt-web")),
+      ("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").excludeAll(
+        "com.typesafe.sbt", "sbt-web",
+        "com.lightbend.paradox" % "sbt-paradox-apidoc",
+        "com.lightbend.paradox" % "sbt-paradox-project-info")),
     addSbtPlugin("com.github.sbt" % "sbt-web" % "1.5.5"), // sbt-paradox 0.9.2 depends on old sbt-web 1.4.x, but we want a newer version
-    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0"),
-    addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1"),
+    addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0").excludeAll(
+      "com.lightbend.paradox", "sbt-paradox")),
+    addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1").excludeAll(
+      "com.lightbend.paradox", "sbt-paradox")),
     addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % "0.7.0"),
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "pekko-paradox.properties"


### PR DESCRIPTION
With this change I can confirm replacing

https://github.com/apache/incubator-pekko-http/blob/main/project/plugins.sbt#L25-L37

with

```scala
addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "1.0.1-RC1+2-dbf8082e+20240303-1152-SNAPSHOT")
```

works properly (I just tried locally)