### PR TITLE
support sbt 2 plugin format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        scala: [2.12.21]
+        scala: [2.12.21, 3.8.4]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -118,6 +118,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.21-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.21)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.8.4)
+        uses: actions/download-artifact@v8
+        with:
+          name: target-${{ matrix.os }}-3.8.4-${{ matrix.java }}
+
+      - name: Inflate target directories (3.8.4)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ ThisBuild / crossScalaVersions := Seq(scala212, scala3)
 
 (pluginCrossBuild / sbtVersion) := {
   scalaBinaryVersion.value match {
-    case "2.12" => "1.12.13"
+    case "2.12" => "1.12.14"
     case _      => "2.0.1"
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,17 @@
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 
 val scala212 = "2.12.21"
+val scala3 = "3.8.4"
 
 ThisBuild / scalaVersion := scala212
-ThisBuild / crossScalaVersions := Seq(scala212)
+ThisBuild / crossScalaVersions := Seq(scala212, scala3)
+
+(pluginCrossBuild / sbtVersion) := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.12.13"
+    case _      => "2.0.1"
+  }
+}
 
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
 ThisBuild / dynverSonatypeSnapshots := true
@@ -80,6 +88,7 @@ lazy val pekkoPlugin = project
     addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "1.1.0"),
     addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "3.0.1"),
     addSbtPlugin("com.github.sbt" % "sbt-paradox-material-theme" % "0.7.0"),
+    addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0"),
     Compile / resourceGenerators += Def.task {
       val file = (Compile / resourceManaged).value / "pekko-paradox.properties"
       IO.write(file, s"pekko.paradox.version=${version.value}")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,7 +26,6 @@ addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.12")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.35")
 addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.31.0")
-addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.31.0")
 
 // https://eed3si9n.com/reducing-scaladoc-file-size-with-sbt-salad-days/
 addSbtPlugin("com.eed3si9n" % "sbt-salad-days" % "0.2.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,3 +26,7 @@ addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.12")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.35")
 addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.31.0")
+addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.31.0")
+
+// https://eed3si9n.com/reducing-scaladoc-file-size-with-sbt-salad-days/
+addSbtPlugin("com.eed3si9n" % "sbt-salad-days" % "0.2.0")


### PR DESCRIPTION
doesn't work because we don't sbt 2 compatible releases for the sbt paradox plugins and there are also build related plugins that don't have sbt 2 releases